### PR TITLE
Add backend structure with NLP parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ This project aims to create an intelligent and user-friendly AI assistant, desig
 * **Database**: SQL (e.g., PostgreSQL, SQLite) for structured storage.
 * **Frontend**: React.js, focusing on clean and intuitive UX/UI.
 
+## Backend Data and Structure
+
+The backend stores **tasks** with the following fields:
+
+- `title` – short description of the assignment or activity.
+- `due_date` – optional deadline in ISO format.
+- `notes` – any additional remarks.
+
+The `backend/` folder now contains:
+
+- `app.py` – entry point running the FastAPI server.
+- `__init__.py` – application factory and route registration.
+- `models.py` – Pydantic data models.
+- `routes.py` – API endpoints for creating and retrieving tasks.
+- `database.py` – simple SQLite helpers.
+- `nlp_task_parser.py` – example script that parses a natural-language task description.
+
+Run the API with:
+
+```bash
+python backend/app.py
+```
+
 ## Project Milestones (Sub-Goals)
 
 * [ ] **Setup Project Environment and Repository**

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,16 @@
+"""Application factory and route registration for FastAPI."""
+
+from fastapi import FastAPI
+
+from .routes import router
+from .database import init_db
+
+app = FastAPI(title="Student Assistant API")
+
+# Initialize the SQLite database on startup
+@app.on_event("startup")
+def on_startup():
+    init_db()
+
+# Register API routes
+app.include_router(router)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,1 +1,7 @@
-# Entry point for backend API (Flask/FastAPI)
+"""Run the FastAPI application."""
+
+from . import app
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,54 @@
+"""Simple SQLite database helpers."""
+
+import sqlite3
+from pathlib import Path
+from typing import List
+
+from .models import Task
+
+DB_PATH = Path("database/assistant.db")
+
+
+def init_db() -> None:
+    """Create the tasks table if it doesn't exist."""
+    DB_PATH.parent.mkdir(exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            due_date TEXT,
+            notes TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_task(task: Task) -> None:
+    """Insert a task into the database."""
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO tasks (title, due_date, notes) VALUES (?, ?, ?)",
+        (task.title, task.due_date.isoformat() if task.due_date else None, task.notes),
+    )
+    conn.commit()
+    conn.close()
+
+
+def list_tasks() -> List[Task]:
+    """Retrieve all tasks from the database."""
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    rows = cursor.execute("SELECT title, due_date, notes FROM tasks").fetchall()
+    conn.close()
+    tasks = []
+    for title, due, notes in rows:
+        tasks.append(
+            Task(title=title, due_date=due if due else None, notes=notes)
+        )
+    return tasks

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,12 @@
+"""Pydantic models for API requests and responses."""
+
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+
+class Task(BaseModel):
+    """Represents a single task item."""
+
+    title: str
+    due_date: Optional[datetime] = None
+    notes: Optional[str] = None

--- a/backend/nlp_task_parser.py
+++ b/backend/nlp_task_parser.py
@@ -1,0 +1,37 @@
+"""Very small NLP helper using spaCy to parse tasks and due dates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import spacy
+from dateutil.parser import parse as parse_date
+
+nlp = spacy.load("en_core_web_sm")
+
+@dataclass
+class ParsedTask:
+    """Result of task parsing."""
+
+    title: str
+    due_date: Optional[str] = None
+
+
+def parse_task(text: str) -> ParsedTask:
+    """Parse a natural language task description into components."""
+    doc = nlp(text)
+    for i, token in enumerate(doc):
+        if token.text.lower() in {"by", "due"} and i + 1 < len(doc):
+            date_text = doc[i + 1 :].text
+            try:
+                due = parse_date(date_text, fuzzy=True)
+                return ParsedTask(title=doc[:i].text.strip(), due_date=due.isoformat())
+            except Exception:
+                break
+    return ParsedTask(title=text.strip(), due_date=None)
+
+
+if __name__ == "__main__":
+    example = "Finish math homework by next Friday"
+    print(parse_task(example))

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,0 +1,20 @@
+"""API routes for managing tasks."""
+
+from fastapi import APIRouter
+from typing import List
+
+from .models import Task
+from .database import add_task, list_tasks
+
+router = APIRouter()
+
+@router.post("/tasks", response_model=Task)
+def create_task(task: Task) -> Task:
+    """Store a new task and return it."""
+    add_task(task)
+    return task
+
+@router.get("/tasks", response_model=List[Task])
+def get_tasks() -> List[Task]:
+    """Return all stored tasks."""
+    return list_tasks()


### PR DESCRIPTION
## Summary
- describe tasks stored in the backend and how to run it
- add FastAPI app factory and database helpers
- create API routes and Pydantic models
- provide an NLP task parser example script

## Testing
- `python3 -m py_compile backend/*.py`
- `python3 backend/nlp_task_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b81544a88326b2a8ec7044ef3292